### PR TITLE
Implement AccessControl.for and associated query

### DIFF
--- a/lib/hyrax/acl.rb
+++ b/lib/hyrax/acl.rb
@@ -1,6 +1,7 @@
 require 'valkyrie'
 require 'hyrax/acl/permission'
 require 'hyrax/acl/access_control'
+require 'hyrax/acl/custom_queries'
 
 ##
 # Hyrax Access Control Lists

--- a/lib/hyrax/acl/access_control.rb
+++ b/lib/hyrax/acl/access_control.rb
@@ -26,6 +26,21 @@ module Hyrax
       #   @return [Enumerable<Hyrax::Acl::Permission>]
       attribute :access_to,   Valkyrie::Types::ID
       attribute :permissions, Valkyrie::Types::Set.of(Hyrax::Acl::Permission)
+
+      ##
+      # A finder/factory method for getting an appropriate ACL for a given
+      # resource.
+      #
+      # @param resource [Valkyrie::Resource]
+      # @param query_service [#find_inverse_references_by]
+      #
+      # @return [AccessControl]
+      # @raise [ArgumentError] if the resource is not persisted
+      def self.for(resource:, query_service: Hyrax.query_service)
+        query_service.custom_queries.find_access_control_for(resource)
+      rescue Valkyrie::Persistence::ObjectNotFoundError
+        new(access_to: resource.id)
+      end
     end
   end
 end

--- a/lib/hyrax/acl/custom_queries.rb
+++ b/lib/hyrax/acl/custom_queries.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'hyrax/acl/custom_queries/find_access_control'
+
+module Hyrax
+  module Acl
+    ##
+    # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
+    # @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#custom-queriesy
+    module CustomQueries
+    end
+  end
+end

--- a/lib/hyrax/acl/custom_queries/find_access_control.rb
+++ b/lib/hyrax/acl/custom_queries/find_access_control.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module Hyrax
+  module Acl
+    module CustomQueries
+      # @example
+      #   Hyrax.custom_queries.find_access_control_for(resource: resource)
+      class FindAccessControl
+        def self.queries
+          [:find_access_control_for]
+        end
+
+        def initialize(query_service:)
+          @query_service = query_service
+        end
+
+        attr_reader :query_service
+        delegate :resource_factory, to: :query_service
+
+        def find_access_control_for(resource)
+          query_service
+            .find_inverse_references_by(resource: resource, property: :access_to)
+            .find { |r| r.is_a?(Hyrax::Acl::AccessControl) } ||
+            raise(Valkyrie::Persistence::ObjectNotFoundError)
+        rescue ArgumentError # some adapters raise ArgumentError for missing resources
+          raise(Valkyrie::Persistence::ObjectNotFoundError)
+        end
+      end
+    end
+  end
+end

--- a/spec/hyrax/acl/access_control_spec.rb
+++ b/spec/hyrax/acl/access_control_spec.rb
@@ -4,10 +4,12 @@ require 'valkyrie/specs/shared_specs'
 
 RSpec.describe Hyrax::Acl::AccessControl do
   subject(:access_control) { described_class.new }
-  let(:permission)         { Hyrax::Acl::Permission.new(access_to: Valkyrie::ID.new('moomin')) }
-  let(:adapter)            { Valkyrie::Persistence::Memory::MetadataAdapter.new }
-  let(:persister)          { adapter.persister }
-  let(:query_service)      { adapter.query_service }
+  let(:adapter) { Valkyrie::Persistence::Memory::MetadataAdapter.new }
+  let(:persister) { adapter.persister }
+  let(:query_service) { adapter.query_service }
+
+  let(:controlled_resource_class) { Class.new(Valkyrie::Resource) }
+  let(:controlled_resource) { controlled_resource_class.new(id: 'etaoin') }
 
   let(:resource_klass) { Class.new(Valkyrie::Resource) }
 
@@ -25,8 +27,47 @@ RSpec.describe Hyrax::Acl::AccessControl do
     expect(query_service.find_by(id: saved.id).permissions).to be_empty
   end
 
+  describe '.for' do
+    let(:retrieved_access_control) do
+      described_class.for(
+        resource: controlled_resource,
+        query_service: query_service
+      )
+    end
+
+    before do
+      query_service.custom_queries.register_query_handler(
+        Hyrax::Acl::CustomQueries::FindAccessControl
+      )
+    end
+
+    it 'returns an access control model for the resource given' do
+      expect(retrieved_access_control)
+        .to have_attributes(access_to: controlled_resource.id)
+    end
+
+    it 'returns an empty access control for an unpersisted resource' do
+      expect(retrieved_access_control)
+        .to have_attributes(permissions: be_empty)
+    end
+
+    context 'when an AccessControl already exists' do
+      let(:controlled_resource) { persister.save(resource: controlled_resource_class.new) }
+
+      before do
+        persister.save(
+          resource: described_class.new(access_to: controlled_resource.id)
+        )
+      end
+
+      it 'reloads persisted data' do
+        expect(retrieved_access_control).to be_persisted
+      end
+    end
+  end
+
   describe '#access_to' do
-    let(:target_id) { Valkyrie::ID.new('moomin') }
+    let(:target_id) { controlled_resource.id }
 
     it 'grants access to a specific resource' do
       expect { access_control.access_to = target_id }
@@ -36,7 +77,7 @@ RSpec.describe Hyrax::Acl::AccessControl do
 
     context 'with permissions and target' do
       let(:access_control) { described_class.new(access_to: target_id, permissions: [permission]) }
-      let(:permission)     { Hyrax::Acl::Permission.new(mode: :read, agent: 'moomin', access_to: target_id) }
+      let(:permission) { Hyrax::Acl::Permission.new(mode: :read, agent: 'moomin', access_to: target_id) }
 
       it 'retains its own access_to target' do
         expect(persister.save(resource: access_control))
@@ -45,14 +86,21 @@ RSpec.describe Hyrax::Acl::AccessControl do
 
       it 'retains access_to target on the created permissions' do
         expect(persister.save(resource: access_control))
-          .to have_attributes(permissions: contain_exactly(have_attributes(mode: permission.mode,
-                                                                           agent: permission.agent,
-                                                                           access_to: permission.access_to)))
+          .to have_attributes(
+            permissions: contain_exactly(have_attributes(
+              mode: permission.mode,
+              agent: permission.agent,
+              access_to: permission.access_to
+            ))
+          )
       end
     end
   end
 
   describe '#permissions' do
+    let(:permission) { Hyrax::Acl::Permission.new(mode: :read, agent: 'moomin', access_to: target_id) }
+    let(:target_id) { controlled_resource.id }
+
     it 'maintains a list of permission policies' do
       expect { access_control.permissions = [permission] }
         .to change { access_control.permissions }
@@ -60,15 +108,16 @@ RSpec.describe Hyrax::Acl::AccessControl do
     end
 
     context 'with permissions' do
-      let(:permission) { Hyrax::Acl::Permission.new(mode: :read, agent: 'moomin', access_to: target_id) }
-      let(:target_id) { Valkyrie::ID.new('moomin') }
-
       before { access_control.permissions = [permission] }
 
       it 'can save with default adapter' do
         expect(persister.save(resource: access_control))
-          .to have_attributes(permissions: contain_exactly(have_attributes(mode: permission.mode,
-                                                                           agent: permission.agent)))
+          .to have_attributes(
+            permissions: contain_exactly(have_attributes(
+              mode: permission.mode,
+              agent: permission.agent
+            ))
+          )
       end
 
       it 'can delete permissions' do
@@ -86,14 +135,18 @@ RSpec.describe Hyrax::Acl::AccessControl do
     end
 
     context 'with group permissions' do
-      let(:permission) { Hyrax::Acl::Permission.new(access_to: Valkyrie::ID.new('moomin'), agent: 'group/public') }
+      let(:permission) { Hyrax::Acl::Permission.new(mode: :read, agent: 'group/public', access_to: target_id) }
 
       it 'can save a group permission' do
         access_control.permissions = [permission]
 
         expect(persister.save(resource: access_control))
-          .to have_attributes(permissions: contain_exactly(have_attributes(mode: permission.mode,
-                                                                           agent: permission.agent)))
+          .to have_attributes(
+            permissions: contain_exactly(have_attributes(
+              mode: permission.mode,
+              agent: permission.agent
+            ))
+          )
       end
     end
   end

--- a/spec/hyrax/acl/custom_queries/find_access_control_spec.rb
+++ b/spec/hyrax/acl/custom_queries/find_access_control_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Hyrax::Acl::CustomQueries::FindAccessControl do
+  subject(:query_handler) { described_class.new(query_service: query_service) }
+  let(:adapter) { Valkyrie::Persistence::Memory::MetadataAdapter.new }
+  let(:persister) { adapter.persister }
+  let(:query_service) { adapter.query_service }
+  let(:resource_class) { Class.new(Valkyrie::Resource) }
+
+  describe '#find_access_control' do
+    context 'for missing object' do
+      let(:resource) { resource_class.new }
+
+      it 'raises ObjectNotFoundError' do
+        expect { query_handler.find_access_control_for(resource) }
+          .to raise_error { Valkyrie::Persistence::ObjectNotFoundError }
+      end
+    end
+
+    context 'when an acl exists' do
+      let(:acl) do
+        persister.save(
+          resource: Hyrax::Acl::AccessControl.new(access_to: resource.id)
+        )
+      end
+      let(:resource) { persister.save(resource: resource_class.new) }
+
+      before { acl } # ensure the acl gets saved
+
+      it 'returns the acl' do
+        expect(query_handler.find_access_control_for(resource))
+          .to eq acl
+      end
+    end
+
+    context 'for another class purporting to provide access_to' do
+      let(:malicious_acl) { malicious_acl_class }
+      let(:resource) { persister.save(resource: resource_class.new) }
+
+      let(:malicious_acl_class) do
+        Class.new(Valkyrie::Resource) do
+          attribute :access_to, Valkyrie::Types::ID
+        end
+      end
+
+      it 'raises ObjectNotFoundError' do
+        expect { query_handler.find_access_control_for(resource) }
+          .to raise_error { Valkyrie::Persistence::ObjectNotFoundError }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This requires supplying a custom query, `Hyrax::Acl::CustomQueries::FindAccessControl`. For some reason, I couldn’t get specs to pass when the signature of this query used `resource:` (with colon), which is what Hyrax’s version of this query uses. It works fine if you implement it without the colon.

I feel a little weird about the overall architecture of this, since it expects `Hyrax.query_service` to be defined, and that feels weird (although manageably so) for applications using this gem on its own. We may want to consider that integration point in more detail.

(The query service *can* be specified as something other than `Hyrax.query_service`, which is how the tests handle things, but I’m not sure this will be ergonomic at actual point of use. Maybe it will be fine?)