### PR TITLE
Add ACL group read interface - By @tchu and @lsitu.

### DIFF
--- a/lib/hyrax/acl.rb
+++ b/lib/hyrax/acl.rb
@@ -2,6 +2,7 @@ require 'valkyrie'
 require 'hyrax/acl/permission'
 require 'hyrax/acl/access_control'
 require 'hyrax/acl/custom_queries'
+require 'hyrax/acl/access_control_list'
 
 ##
 # Hyrax Access Control Lists

--- a/lib/hyrax/acl.rb
+++ b/lib/hyrax/acl.rb
@@ -1,5 +1,6 @@
 require 'valkyrie'
 require 'hyrax/acl/agent'
+require 'hyrax/acl/group'
 require 'hyrax/acl/permission'
 require 'hyrax/acl/access_control'
 require 'hyrax/acl/custom_queries'

--- a/lib/hyrax/acl.rb
+++ b/lib/hyrax/acl.rb
@@ -1,4 +1,5 @@
 require 'valkyrie'
+require 'hyrax/acl/agent'
 require 'hyrax/acl/permission'
 require 'hyrax/acl/access_control'
 require 'hyrax/acl/custom_queries'

--- a/lib/hyrax/acl/access_control_list.rb
+++ b/lib/hyrax/acl/access_control_list.rb
@@ -30,28 +30,28 @@ module Hyrax
 
       ##
       # Discover grant
-      # @agent [Hyrax::Agent] agent
+      # @agent [Hyrax::Acl::Agent] agent
       def has_discover?(agent:)
         has_grant?(mode: DISCOVER, agent: agent)
       end
 
       ##
       # Read grant
-      # @agent [Hyrax::Agent] agent
+      # @agent [Hyrax::Acl::Agent] agent
       def has_read?(agent:)
         has_grant?(mode: READ, agent: agent)
       end
 
       ##
       # Edit grant
-      # @agent [Hyrax::Agent] agent
+      # @agent [Hyrax::Acl::Agent] agent
       def has_edit?(agent:)
         has_grant?(mode: EDIT, agent: agent)
       end
 
       ##
       # Edit grant
-      # @agent [Hyrax::Agent] agent
+      # @agent [Hyrax::Acl::Agent] agent
       def has_grant?(mode:, agent:)
         permissions.any? do |permission|
           permission.mode ==  mode && permission.agent == agent.agent_key

--- a/lib/hyrax/acl/access_control_list.rb
+++ b/lib/hyrax/acl/access_control_list.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Acl
+    DISCOVER = :discover
+    EDIT     = :edit
+    READ     = :read
+
+    ##
+    # @api public
+    #
+    # ACLs for `Hyrax::Resource` models
+    #
+    # Allows managing `Hyrax::Permission` entries referring to a specific
+    # `Hyrax::Resource.
+    #
+    class AccessControlList
+      ##
+      # @!attribute [r] access_control
+      #   @return [Hyax:Acl:AccessControl]
+      attr_reader :access_control
+
+      ##
+      # @api public
+      #
+      # @param :access_control [Hyax:Acl:AccessControl]
+      def initialize(access_control:)
+        @access_control = access_control
+      end
+
+      ##
+      # Discover grant
+      # @agent_name [string] agent
+      def has_discover?(agent:)
+        has_grant?(mode: DISCOVER, agent: agent)
+      end
+
+      ##
+      # Read grant
+      # @agent_name [string] agent
+      def has_read?(agent:)
+        has_grant?(mode: READ, agent: agent)
+      end
+
+      ##
+      # Edit grant
+      # @agent_name [string] agent
+      def has_edit?(agent:)
+        has_grant?(mode: EDIT, agent: agent)
+      end
+
+      ##
+      # Edit grant
+      # @agent_name [string] agent
+      def has_grant?(mode:, agent:)
+        permissions.any? do |permission|
+          permission.mode ==  mode && permission.agent == agent
+        end
+      end
+
+      ##
+      # @api public
+      #
+      # @return [Set<Hyrax::Permission>]
+      def permissions
+        access_control.permissions
+      end
+    end
+  end
+end

--- a/lib/hyrax/acl/access_control_list.rb
+++ b/lib/hyrax/acl/access_control_list.rb
@@ -30,31 +30,31 @@ module Hyrax
 
       ##
       # Discover grant
-      # @agent_name [string] agent
+      # @agent [Hyrax::Agent] agent
       def has_discover?(agent:)
         has_grant?(mode: DISCOVER, agent: agent)
       end
 
       ##
       # Read grant
-      # @agent_name [string] agent
+      # @agent [Hyrax::Agent] agent
       def has_read?(agent:)
         has_grant?(mode: READ, agent: agent)
       end
 
       ##
       # Edit grant
-      # @agent_name [string] agent
+      # @agent [Hyrax::Agent] agent
       def has_edit?(agent:)
         has_grant?(mode: EDIT, agent: agent)
       end
 
       ##
       # Edit grant
-      # @agent_name [string] agent
+      # @agent [Hyrax::Agent] agent
       def has_grant?(mode:, agent:)
         permissions.any? do |permission|
-          permission.mode ==  mode && permission.agent == agent
+          permission.mode ==  mode && permission.agent == agent.agent_key
         end
       end
 

--- a/lib/hyrax/acl/agent.rb
+++ b/lib/hyrax/acl/agent.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
 module Hyrax
-  class Agent
-    attr_reader :name
+  module Acl
+    class Agent
+      attr_reader :name
 
-    def initialize(name)
-      @name = name
-    end
+      def initialize(name)
+        @name = name
+      end
 
-    ##
-    # @return [String] a local identifier in ACL
-    #   data
-    def agent_key
-      name
+      ##
+      # @return [String] a local identifier in ACL
+      #   data
+      def agent_key
+        name
+      end
     end
   end
 end

--- a/lib/hyrax/acl/agent.rb
+++ b/lib/hyrax/acl/agent.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Hyrax
+  class Agent
+    attr_reader :name
+
+    def initialize(name)
+      @name = name
+    end
+
+    ##
+    # @return [String] a local identifier in ACL
+    #   data
+    def agent_key
+      name
+    end
+  end
+end

--- a/lib/hyrax/acl/group.rb
+++ b/lib/hyrax/acl/group.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Hyrax
+  module Acl
+    class Group < Agent
+      DEFAULT_NAME_PREFIX = 'group/'
+
+      def self.name_prefix
+        DEFAULT_NAME_PREFIX
+      end
+
+      ##
+      # @return [Hyrax::Group]
+      def self.from_agent_key(key)
+        new(key.delete_prefix(name_prefix))
+      end
+
+      def initialize(name)
+        super
+      end
+
+      ##
+      # @return [String] a local identifier for this group; for use (e.g.) in ACL
+      #   data
+      def agent_key
+        self.class.name_prefix + name
+      end
+
+      ##
+      # @return [Boolean]
+      def ==(other)
+        other.class == self.class && other.name == name
+      end
+    end
+  end
+end

--- a/spec/hyrax/acl/access_control_list_spec.rb
+++ b/spec/hyrax/acl/access_control_list_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::Acl::AccessControlList do
   describe '#grant discover access' do
     subject { described_class.new(access_control: access_control) }
 
-    let(:agent) { Hyrax::Agent.new('hyrax_group/superskunk') }
+    let(:agent) { Hyrax::Acl::Agent.new('hyrax_group/superskunk') }
     let(:target_id) { Valkyrie::ID.new('moomin') }
     let(:access_control) { Hyrax::Acl::AccessControl.new(access_to: target_id, permissions: [permission]) }
     let(:permission) { Hyrax::Acl::Permission.new(mode: mode, agent: agent.agent_key, access_to: target_id) }

--- a/spec/hyrax/acl/access_control_list_spec.rb
+++ b/spec/hyrax/acl/access_control_list_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Hyrax::Acl::AccessControlList do
   describe '#grant discover access' do
     subject { described_class.new(access_control: access_control) }
 
-    let(:agent) { 'hyrax_group/superskunk' }
+    let(:agent) { Hyrax::Agent.new('hyrax_group/superskunk') }
     let(:target_id) { Valkyrie::ID.new('moomin') }
     let(:access_control) { Hyrax::Acl::AccessControl.new(access_to: target_id, permissions: [permission]) }
-    let(:permission) { Hyrax::Acl::Permission.new(mode: mode, agent: agent, access_to: target_id) }
+    let(:permission) { Hyrax::Acl::Permission.new(mode: mode, agent: agent.agent_key, access_to: target_id) }
 
     context "discover grant" do
       let(:mode) { :discover }

--- a/spec/hyrax/acl/access_control_list_spec.rb
+++ b/spec/hyrax/acl/access_control_list_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyrax::Acl::AccessControlList do
+  describe '#grant discover access' do
+    subject { described_class.new(access_control: access_control) }
+
+    let(:agent) { 'hyrax_group/superskunk' }
+    let(:target_id) { Valkyrie::ID.new('moomin') }
+    let(:access_control) { Hyrax::Acl::AccessControl.new(access_to: target_id, permissions: [permission]) }
+    let(:permission) { Hyrax::Acl::Permission.new(mode: mode, agent: agent, access_to: target_id) }
+
+    context "discover grant" do
+      let(:mode) { :discover }
+
+      it 'gives a discover permission' do
+        expect(subject.has_discover?(agent: agent))
+          .to be true
+      end
+    end
+
+    context "read grant" do
+      let(:mode) { :read }
+
+      it 'gives a read permission' do
+        expect(subject.has_read?(agent: agent))
+          .to be true
+      end
+    end
+
+    context "edit grant" do
+      let(:mode) { :edit }
+
+      it 'gives an edit permission' do
+        expect(subject.has_edit?(agent: agent))
+          .to be true
+      end
+    end
+  end
+end

--- a/spec/hyrax/acl/group_spec.rb
+++ b/spec/hyrax/acl/group_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Acl::Group, type: :model do
+  let(:name) { 'etaoin' }
+  let(:group) { described_class.new(name) }
+
+  describe '.from_agent_key' do
+    it 'returns an equivalent group' do
+      expect(described_class.from_agent_key(group.agent_key)).to eq group
+    end
+  end
+
+  describe '#name' do
+    it 'returns the name' do
+      expect(group.name).to eq name
+    end
+  end
+
+  describe '#agent_key' do
+    it 'returns the name prefixed with the name prefix' do
+      expect(group.agent_key).to eq described_class.name_prefix + group.name
+    end
+  end
+end


### PR DESCRIPTION
Add interface for group read.

Basing on our discussions, Vivian and I think we only can start with assuming we've got the ACL for a Valkyrie::Resource. It seems like Margret's PR #3 could be a good feed to retrieve the ACL.