### PR TITLE
Remove dependency on custom query registration

### DIFF
--- a/lib/hyrax/acl/access_control.rb
+++ b/lib/hyrax/acl/access_control.rb
@@ -36,8 +36,8 @@ module Hyrax
       #
       # @return [AccessControl]
       # @raise [ArgumentError] if the resource is not persisted
-      def self.for(resource:, query_service: Hyrax.query_service)
-        query_service.custom_queries.find_access_control_for(resource: resource)
+      def self.for(resource:, query_service:)
+        Hyrax::Acl::CustomQueries::FindAccessControl.new(query_service: query_service).find_access_control_for(resource: resource)
       rescue Valkyrie::Persistence::ObjectNotFoundError
         new(access_to: resource.id)
       end

--- a/lib/hyrax/acl/access_control.rb
+++ b/lib/hyrax/acl/access_control.rb
@@ -39,7 +39,7 @@ module Hyrax
       def self.for(resource:, query_service:)
         Hyrax::Acl::CustomQueries::FindAccessControl.new(query_service: query_service).find_access_control_for(resource: resource)
       rescue Valkyrie::Persistence::ObjectNotFoundError
-        new(access_to: resource.id)
+        new(access_to: resource.id, permissions: [])
       end
     end
   end

--- a/spec/hyrax/acl/access_control_spec.rb
+++ b/spec/hyrax/acl/access_control_spec.rb
@@ -35,12 +35,6 @@ RSpec.describe Hyrax::Acl::AccessControl do
       )
     end
 
-    before do
-      query_service.custom_queries.register_query_handler(
-        Hyrax::Acl::CustomQueries::FindAccessControl
-      )
-    end
-
     it 'returns an access control model for the resource given' do
       expect(retrieved_access_control)
         .to have_attributes(access_to: controlled_resource.id)


### PR DESCRIPTION
This is required to make `AccessControl.for` work out of the box.

This may also mitigate the Ruby 3 compatibility problems of samvera/valkyrie#907.